### PR TITLE
Updates and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 .project
 .settings
 target/
+
+# ignore IDEA files
+*.iml
+*.ipr
+*.iws
+.idea
+
+#OS X stuff
+.DS_Store

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -42,6 +42,8 @@
         <findbugs.version>2.5.2</findbugs.version>
         <findbugs.exclude />
         <findbugs.threshold>High</findbugs.threshold>
+
+        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
     </properties>
 
     <contributors>
@@ -208,10 +210,11 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
     </reporting>
 
     <dependencies>
+        <!-- org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec:2.0.0.Final -->
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <version>4.0.2</version>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <spec.version>2.3</spec.version>
         <extensionName>javax.servlet.jsp</extensionName>
-        <bundle.symbolicName>javax.servlet.jsp-api</bundle.symbolicName>
+        <bundle.symbolicName>org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec</bundle.symbolicName>
         <vendorName>Eclipse Foundation</vendorName>
         <findbugs.version>2.5.2</findbugs.version>
         <findbugs.exclude />
@@ -96,14 +96,21 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>1.4.3</version>
                 <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultSpecificationEntries>false</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
                     <supportedProjectTypes>
                         <supportedProjectType>jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
                         <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
                         <_include>-osgi.bundle</_include>
+                        <Export-Package>
+                            javax.servlet.jsp*;version=2.3
+                        </Export-Package>
                     </instructions>
                 </configuration>
                 <executions>
@@ -126,6 +133,7 @@
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         <manifestEntries>
+                            <Automatic-Module-Name>beta.jboss.jsp.api_2_3</Automatic-Module-Name>
                             <Extension-Name>${extensionName}</Extension-Name>
                             <!--Specification-Title>${specificationTitle}</Specification-Title-->
                             <Specification-Version>${spec.version}</Specification-Version>

--- a/api/src/main/java/javax/servlet/jsp/JspContext.java
+++ b/api/src/main/java/javax/servlet/jsp/JspContext.java
@@ -184,7 +184,6 @@ public abstract class JspContext {
      * @return A valid instance of an ExpressionEvaluator.
      * @since JSP 2.0
      */
-    @Deprecated
     public abstract javax.servlet.jsp.el.ExpressionEvaluator getExpressionEvaluator();
 
     /**
@@ -196,7 +195,6 @@ public abstract class JspContext {
      * @return A valid instance of a VariableResolver.
      * @since JSP 2.0
      */
-    @Deprecated
     public abstract javax.servlet.jsp.el.VariableResolver getVariableResolver();
 
     /**

--- a/api/src/main/java/javax/servlet/jsp/JspException.java
+++ b/api/src/main/java/javax/servlet/jsp/JspException.java
@@ -75,7 +75,6 @@ public class JspException extends Exception {
      *
      * @deprecated As of JSP 2.1, replaced by {@link #getCause()}
      */
-    @Deprecated
     public Throwable getRootCause() {
         return getCause();
     }

--- a/api/src/main/java/javax/servlet/jsp/tagext/BodyTag.java
+++ b/api/src/main/java/javax/servlet/jsp/tagext/BodyTag.java
@@ -103,7 +103,6 @@ public interface BodyTag extends IterationTag {
      *
      * @deprecated As of Java JSP API 1.2, use BodyTag.EVAL_BODY_BUFFERED or IterationTag.EVAL_BODY_AGAIN.
      */
-    @Deprecated
     public final static int EVAL_BODY_TAG = 2;
 
     /**

--- a/api/src/main/java/javax/servlet/jsp/tagext/TagSupport.java
+++ b/api/src/main/java/javax/servlet/jsp/tagext/TagSupport.java
@@ -63,7 +63,7 @@ public class TagSupport implements IterationTag, Serializable {
      * @param klass The subclass of Tag or interface to be matched
      * @return the nearest ancestor that implements the interface or is an instance of the class specified
      */
-    public static final Tag findAncestorWithClass(Tag from, Class<?> klass) {
+    public static final Tag findAncestorWithClass(Tag from, Class klass) {
         boolean isInterface = false;
 
         if (from == null || klass == null


### PR DESCRIPTION
@fl4via I can't quite figure out what master was based on. I see that https://github.com/jboss/jboss-jakarta-jsp-api_spec/commit/17e5635ce37b0f6ae2fb6173fef44e4b43fd15aa is on our master which was done on 2019-08-03 however looking at the [tag](https://github.com/eclipse-ee4j/jsp-api/commits/2.3.6-RELEASE) it's got https://github.com/eclipse-ee4j/jsp-api/commit/bba5c2c7259985afbd36eaeb2b04a77f755f53e3 with a different commit id. I'm not sure what happened, but we might need to reset master and put our commits back on top. 

These 3 commits can just be added at any point or let me know and I'll submit a new PR once master is fixed.